### PR TITLE
Update Codecademy link and add new Python resource

### DIFF
--- a/docs/docs/Resources/technical-resources.md
+++ b/docs/docs/Resources/technical-resources.md
@@ -33,11 +33,13 @@ These represent a small selection of guides, tutorials, and quick references for
 
 [Automate the Boring Stuff with Python](https://automatetheboringstuff.com/)
 
-[Codecademy Python Course](https://www.codecademy.com/tracks/python)
+[Codecademy Python Course](https://www.codecademy.com/catalog/language/python)
 
 [Python 2.7 Quick Reference](http://rgruet.free.fr/PQR27/PQR2.7.html)
 
 [NumPy for MATLAB Users](http://mathesaurus.sourceforge.net/matlab-numpy.html)
+
+[Python Online Courses](https://classpert.com/python-programming)
 
 ## Useful Apps
 


### PR DESCRIPTION
Codecademy's Python page is no longer available at the link that was listed. Updating the reference to a working link.

Also, we are launching Classpert.com, a meta search engine for online courses. We have a collection of Python courses, crawled from providers like Udemy, Coursera, Treehouse, etc.,, so I figured it might be useful for newcomers.